### PR TITLE
remove incorrect use of graph_from_adjacency_matrix()

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -10,8 +10,7 @@ graph_metrics <- function(graph, verbose = TRUE, return = FALSE) {
   #' @export
   #'
   #' @examples
-  #' adj_mat <- matrix(rnorm(36),nrow=6)
-  #' graph <- igraph::graph_from_adjacency_matrix(adj_mat)
+  #' graph <- igraph::sample_gnm(100,100)
   #' graph_metrics(graph, verbose = TRUE, return = FALSE)
   #'
   #'


### PR DESCRIPTION
This corrects an invalid use of `graph_from_adjacency_matrix()`.

The matrix you passed in had both positive and negative real numbers. An adjacency matrix should have non-negative integers. An upcoming versions of igraph will throw an error on this.
